### PR TITLE
fix php 8.2 deprecation

### DIFF
--- a/includes/class-mas-wc-brands-admin-settings.php
+++ b/includes/class-mas-wc-brands-admin-settings.php
@@ -7,6 +7,7 @@
 if ( ! class_exists( 'Mas_WC_Brands_Admin_Settings' ) ) {
 	class Mas_WC_Brands_Admin_Settings {
 
+		var $settings;
 		var $settings_tabs;
 		var $current_tab;
 		var $fields = array();


### PR DESCRIPTION
### Steps to test the issue

1. Add mas-woocommerce-brands plugin to the site
2. Make the site php version to 8.2, deprecation notice will be on top of the site, (set wp-config to true)
3. Checkout to this branch and refresh the page, deprecation notice should be gone
